### PR TITLE
Add max age

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules
 npm-debug.log
 /package-lock.json
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const memoizee = require('memoizee');
 const log = require('log').get('aws-ssm-parameter');
 const SSM = require('aws-sdk/clients/ssm');
 
-const { SSM_PARAMETERS_PATH } = process.env;
+const { SSM_PARAMETERS_PATH, SSM_MAX_AGE } = process.env;
 
 const ssm = new SSM({
   maxRetries: 5,
@@ -41,6 +41,7 @@ module.exports = memoizee(
   },
   {
     length: 1,
+    maxAge: SSM_MAX_AGE,
     promise: true,
     resolvers: [
       path => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-ssm-parameter-resolve",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Automated parameters resolution from AWS Systems Manager Parameter Store",
   "author": "MaaS Global",
   "repository": "maasglobal/aws-ssm-parameter-resolve",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "lint-staged": "^8.1.5",
     "log-node": "^7.0.0",
     "mocha": "^6.1.2",
-    "nyc": "^13.3.0",
+    "nyc": "^14.1.1",
     "prettier": "^1.16.4",
-    "proxyquire": "^2.1.0"
+    "sinon": "^7.3.2"
   },
   "husky": {
     "hooks": {

--- a/test/index.js
+++ b/test/index.js
@@ -3,14 +3,41 @@
 'use strict';
 
 const { expect } = require('chai');
-const proxyquire = require('proxyquire');
+const sandbox = require('sinon').createSandbox();
+const AWS = require('aws-sdk');
 
-class SSMMock {
-  getParametersByPath(options) {
-    return {
-      promise() {
-        if (options.Path === '/default-path/') {
-          return Promise.resolve({
+process.env.SSM_PARAMETERS_PATH = '/default-path/';
+process.env.SSM_MAX_AGE = 100;
+
+const parameterResolve = require('../');
+
+// const FAKE_NOW = 1483228800000;
+
+function sleep(time) {
+  return new Promise(resolve => setTimeout(() => resolve(), time));
+}
+
+describe('aws-ssm-parameter-resolve', () => {
+  let defaultPathStub;
+  let customPathStub;
+  // let clock;
+  let ssmStub;
+  before(() => {
+    // clock = sandbox.useFakeTimers(FAKE_NOW);
+    ssmStub = sandbox.stub(AWS.SSM.prototype, 'makeRequest');
+  });
+
+  beforeEach(async () => {
+    defaultPathStub = ssmStub
+      .withArgs('getParametersByPath', {
+        Path: '/default-path/',
+        WithDecryption: true,
+        Recursive: true,
+        NextToken: undefined,
+      })
+      .returns({
+        promise: () =>
+          Promise.resolve({
             Parameters: [
               {
                 Name: '/default-path/ENDPOINT_KEY',
@@ -29,10 +56,19 @@ class SSMMock {
                 ARN: 'arn:aws:ssm:eu-west-1:756207178743:parameter/default-path/ENDPOINT_URL',
               },
             ],
-          });
-        }
-        if (options.Path === '/custom-path/') {
-          return Promise.resolve({
+          }),
+      });
+
+    customPathStub = ssmStub
+      .withArgs('getParametersByPath', {
+        Path: '/custom-path/',
+        WithDecryption: true,
+        Recursive: true,
+        NextToken: undefined,
+      })
+      .returns({
+        promise: () =>
+          Promise.resolve({
             Parameters: [
               {
                 Name: '/custom-path/CUSTOM_KEY',
@@ -51,28 +87,35 @@ class SSMMock {
                 ARN: 'arn:aws:ssm:eu-west-1:756207178743:parameter/custom-path/ENDPOINT_URL',
               },
             ],
-          });
-        }
-        return Promise.reject(new Error('No mock resolved'));
-      },
-    };
-  }
-}
+          }),
+      });
+  });
 
-process.env.SSM_PARAMETERS_PATH = '/default-path/';
-const parameterResolve = proxyquire('../', { 'aws-sdk/clients/ssm': SSMMock });
+  afterEach(() => {
+    defaultPathStub.reset();
+    customPathStub.reset();
+    parameterResolve.clear();
+  });
 
-describe('aws-ssm-parameter-resolve', () => {
+  after(() => {
+    // clock.restore();
+    sandbox.restore();
+  });
+
   it('Should resolve secret values by default from SSM_PARAMETERS_PATH', async () => {
     const params = await parameterResolve();
     expect(params.get('ENDPOINT_KEY')).to.equal('some-fii');
     expect(params.get('ENDPOINT_URL')).to.equal('some-elo');
+    await parameterResolve(); // call second time, should be cached
+    expect(defaultPathStub.callCount).to.equal(1);
   });
 
   it('Should resolve secret values from custom path', async () => {
     const params = await parameterResolve('/custom-path/');
     expect(params.get('CUSTOM_KEY')).to.equal('some-fii-custom');
     expect(params.get('ENDPOINT_URL')).to.equal('some-custom-elo');
+    await parameterResolve(); // call second time, should be cached
+    expect(customPathStub.callCount).to.equal(1);
   });
 
   it('Should crash if secret is not resolved', async () => {
@@ -83,5 +126,16 @@ describe('aws-ssm-parameter-resolve', () => {
     } catch (error) {
       expect(error.code).to.equal('SECRET_NOT_FOUND');
     }
+    expect(defaultPathStub.callCount).to.equal(1);
+  });
+
+  it('Should resolve secret values by default from SSM_PARAMETERS_PATH with max age', async () => {
+    await parameterResolve();
+    expect(defaultPathStub.callCount).to.equal(1);
+    await parameterResolve();
+    await sleep(300);
+    // clock.tick(300)
+    await parameterResolve();
+    expect(defaultPathStub.callCount).to.equal(2);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -7,11 +7,9 @@ const sandbox = require('sinon').createSandbox();
 const AWS = require('aws-sdk');
 
 process.env.SSM_PARAMETERS_PATH = '/default-path/';
-process.env.SSM_MAX_AGE = 100;
+process.env.SSM_MAX_AGE = 10;
 
 const parameterResolve = require('../');
-
-// const FAKE_NOW = 1483228800000;
 
 function sleep(time) {
   return new Promise(resolve => setTimeout(() => resolve(), time));
@@ -20,10 +18,8 @@ function sleep(time) {
 describe('aws-ssm-parameter-resolve', () => {
   let defaultPathStub;
   let customPathStub;
-  // let clock;
   let ssmStub;
   before(() => {
-    // clock = sandbox.useFakeTimers(FAKE_NOW);
     ssmStub = sandbox.stub(AWS.SSM.prototype, 'makeRequest');
   });
 
@@ -98,7 +94,6 @@ describe('aws-ssm-parameter-resolve', () => {
   });
 
   after(() => {
-    // clock.restore();
     sandbox.restore();
   });
 
@@ -129,12 +124,11 @@ describe('aws-ssm-parameter-resolve', () => {
     expect(defaultPathStub.callCount).to.equal(1);
   });
 
-  it('Should resolve secret values by default from SSM_PARAMETERS_PATH with max age', async () => {
+  it('Should fetch parameters from SSM twice because of max age', async () => {
+    await parameterResolve();
     await parameterResolve();
     expect(defaultPathStub.callCount).to.equal(1);
-    await parameterResolve();
-    await sleep(300);
-    // clock.tick(300)
+    await sleep(30);
     await parameterResolve();
     expect(defaultPathStub.callCount).to.equal(2);
   });


### PR DESCRIPTION
This PR adds a possibility to expire the cache after a defined amount of milliseconds using `SSM_MAX_AGE` environmental variable. If the variable is not set, the max age is ignored.

This feature is useful when e.g. while Lambda function is warm and new variables should be loaded. By setting max age, Lambda will then fetch fresh variables after the cache is expired.