### PR TITLE
Strict get

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ npm install aws-ssm-paramter-resolve
 Resolve parameters from common path, if not passed as an argument, it is read from `SSM_PARAMETERS_PATH` env variable.
 
 ```javascript
-const ssmParameterResolve = require('aws-ssm-paramter-resolve');
+const ssmParameterResolver = require('aws-ssm-parameter-resolve');
 
-ssmParameterResolve().then(parameters => {
+ssmParameterResolver.resolve().then(parameters => {
   // Assuming process.env.SSM_PARAMETERS_PATH is '/secrets/foo/'
   console.log(`Param for /secrets/foo/api-key: ${parameters.get('api-key')}`);
 });
 
-ssmParameterResolve('/secrets/bar/').then(parameters =>
-  console.log(`Resolved /secrets/bar/api-key ${parameters.get('api-key')}`)
-);
+ssmParameterResolver
+  .resolve('/secrets/bar/')
+  .then(parameters => console.log(`Resolved /secrets/bar/api-key ${parameters.get('api-key')}`));
 ```
 
 ## Test & coverage

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function strictGetMethod(name) {
 
 module.exports = memoizee(
   async (path = null) => {
-    const result = Object.defineProperty(new Map(), 'get', d(strictGetMethod));
+    const result = Object.defineProperty(new Map(), 'strictGet', d(strictGetMethod));
     let nextToken;
     do {
       const awsResult = await ssm

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const ssm = new SSM({
 function strictGetMethod(name) {
   name = ensureString(name);
   const value = Map.prototype.get.call(this, name);
-  if (!value) throw Object.assign(new Error(`${name} secret not found`), { code: 'SECRET_NOT_FOUND' });
+  if (!value) throw Object.assign(new Error(`${name} parameter not found`), { code: 'PARAMETER_NOT_FOUND' });
   return value;
 }
 
@@ -48,7 +48,7 @@ module.exports = memoizee(
         if (!isValue(path)) {
           if (!SSM_PARAMETERS_PATH) {
             throw Object.assign(new Error('Missing SSM_PARAMETERS_PATH environment variable'), {
-              code: 'SECRETS_PATH_UNDEFINED',
+              code: 'PARAMETERS_PATH_UNDEFINED',
             });
           }
           path = SSM_PARAMETERS_PATH;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-ssm-parameter-resolve",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Automated parameters resolution from AWS Systems Manager Parameter Store",
   "author": "MaaS Global",
   "repository": "maasglobal/aws-ssm-parameter-resolve",

--- a/test/index.js
+++ b/test/index.js
@@ -113,10 +113,15 @@ describe('aws-ssm-parameter-resolve', () => {
     expect(customPathStub.callCount).to.equal(1);
   });
 
-  it('Should crash if secret is not resolved', async () => {
+  it('Should not crash if secret is not resolved', async () => {
+    const params = await parameterResolve();
+    expect(params.get('NOT_EXISTING')).to.equal(undefined);
+  });
+
+  it('Should crash if secret is strictly not resolved', async () => {
     const params = await parameterResolve();
     try {
-      params.get('NOT_EXISTING');
+      params.strictGet('NOT_EXISTING');
       throw new Error('Not really');
     } catch (error) {
       expect(error.code).to.equal('SECRET_NOT_FOUND');

--- a/test/index.js
+++ b/test/index.js
@@ -97,7 +97,7 @@ describe('aws-ssm-parameter-resolve', () => {
     sandbox.restore();
   });
 
-  it('Should resolve secret values by default from SSM_PARAMETERS_PATH', async () => {
+  it('Should resolve parameter values by default from SSM_PARAMETERS_PATH', async () => {
     const params = await parameterResolve();
     expect(params.get('ENDPOINT_KEY')).to.equal('some-fii');
     expect(params.get('ENDPOINT_URL')).to.equal('some-elo');
@@ -105,7 +105,7 @@ describe('aws-ssm-parameter-resolve', () => {
     expect(defaultPathStub.callCount).to.equal(1);
   });
 
-  it('Should resolve secret values from custom path', async () => {
+  it('Should resolve parameter values from custom path', async () => {
     const params = await parameterResolve('/custom-path/');
     expect(params.get('CUSTOM_KEY')).to.equal('some-fii-custom');
     expect(params.get('ENDPOINT_URL')).to.equal('some-custom-elo');
@@ -113,18 +113,18 @@ describe('aws-ssm-parameter-resolve', () => {
     expect(customPathStub.callCount).to.equal(1);
   });
 
-  it('Should not crash if secret is not resolved', async () => {
+  it('Should not crash if parameter is not resolved', async () => {
     const params = await parameterResolve();
     expect(params.get('NOT_EXISTING')).to.equal(undefined);
   });
 
-  it('Should crash if secret is strictly not resolved', async () => {
+  it('Should crash if parameter is strictly not resolved', async () => {
     const params = await parameterResolve();
     try {
       params.strictGet('NOT_EXISTING');
       throw new Error('Not really');
     } catch (error) {
-      expect(error.code).to.equal('SECRET_NOT_FOUND');
+      expect(error.code).to.equal('PARAMETER_NOT_FOUND');
     }
     expect(defaultPathStub.callCount).to.equal(1);
   });


### PR DESCRIPTION
- add `strictGet` to the `Map` structure, rather than overwriting `get`
- export an object rather than a function to make it easier for downstream testing